### PR TITLE
Added wait for mysql to start to avoid issues in oidc install

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -67,6 +67,9 @@ drenv -d -p 3306:3306 -e "MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD" --volumes-fr
 echo " -> done" &&
 echo "" && 
 
+echo "Waiting 4 seconds for MySql to start"
+sleep 4
+
 # start Layers Adapter data volume container
 echo "Starting Layers Adapter data volume..." &&
 drenv --name adapter-data learninglayers/adapter-data &&


### PR DESCRIPTION
Hi guys,

Can you please pull my changes... without this pause the oidc install fails on our local docker, because MySql has not completely started when oidc tries to link, failing to create its database.

Thanks,
Raymond
