### PR TITLE
Sss stuff

### DIFF
--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -9,20 +9,24 @@ RUN apt-get update && apt-get install -y perl --no-install-recommends && rm -rf 
 # gpg: key 5072E1F5: public key "MySQL Release Engineering <mysql-build@oss.oracle.com>" imported
 RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys A4A9406876FCBD3C456770C88C718D3B5072E1F5
 
-#ENV MYSQL_VERSION 5.6
+ENV MYSQL_MAJOR 5.6
+ENV MYSQL_VERSION 5.6.26
+
+RUN echo "deb http://repo.mysql.com/apt/debian/ wheezy mysql-${MYSQL_MAJOR}" > /etc/apt/sources.list.d/mysql.list
 
 # the "/var/lib/mysql" stuff here is because the mysql-server postinst doesn't have an explicit way to disable the mysql_install_db codepath besides having a database already "configured" (ie, stuff in /var/lib/mysql/mysql)
 # also, we set debconf keys to make APT a little quieter
+
 RUN { \
  echo mysql-community-server mysql-community-server/data-dir select ''; \
  echo mysql-community-server mysql-community-server/root-pass password ''; \
  echo mysql-community-server mysql-community-server/re-root-pass password ''; \
  echo mysql-community-server mysql-community-server/remove-test-db select false; \
 } | debconf-set-selections \
-                            && apt-get update && apt-get install -y mysql-server\
-                            && rm -rf /var/lib/apt/lists/* \
-                            && rm -rf /var/lib/mysql \
-                            && mkdir -p /var/lib/mysql
+	&& apt-get update && apt-get install -y mysql-server="${MYSQL_VERSION}"*\
+    && rm -rf /var/lib/apt/lists/* \
+	&& rm -rf /var/lib/mysql \ 
+    && mkdir -p /var/lib/mysql
 
 # comment out a few problematic configuration values
 RUN sed -Ei 's/^(bind-address|log)/#&/' /etc/mysql/my.cnf

--- a/sss/Dockerfile
+++ b/sss/Dockerfile
@@ -1,11 +1,13 @@
-FROM learninglayers/java
+FROM java:8-jre
 
 MAINTAINER Dieter Theiler "dtheiler@tugraz.at"
 
 ADD https://github.com/learning-layers/SocialSemanticServer/releases/download/v9.0.0-alpha/sss.package.zip /
+#COPY sss.package.zip /
 
 RUN apt-get update
-RUN apt-get install -y unzip mysql-client vim sed
+RUN apt-get install -y unzip mysql-client vim
+RUN apt-get install -y sed
 
 EXPOSE 8390
 

--- a/sss/Dockerfile
+++ b/sss/Dockerfile
@@ -2,7 +2,7 @@ FROM java:8-jre
 
 MAINTAINER Dieter Theiler "dtheiler@tugraz.at"
 
-ADD https://github.com/learning-layers/SocialSemanticServer/releases/download/v9.0.0-alpha/sss.package.zip /
+ADD https://github.com/learning-layers/SocialSemanticServer/releases/download/v11.0.0-alpha/sss.package.zip /
 #COPY sss.package.zip /
 
 RUN apt-get update

--- a/sss/entrypoint.sh
+++ b/sss/entrypoint.sh
@@ -8,7 +8,7 @@ echo "done --> extracting SSS package"
 echo "importing SSS MySQL db ..."
 cd /sss.package/sss.app/
 sed -i "s#SSS_MYSQL_SCHEME#${SSS_MYSQL_SCHEME}#g" ./sss.schema.sql
-mysql -uroot -p$MYSQL_ROOT_PASSWORD -hmysql < ./sss.schema.sql
+mysql -u$SSS_MYSQL_USERNAME -p$SSS_MYSQL_PASSWORD -hmysql < ./sss.schema.sql
 echo "done -> importing SSS MySQL db"
 
 echo "setting Tomcat SSS config ..."

--- a/start.sh
+++ b/start.sh
@@ -255,42 +255,52 @@ echo "" &&
 # Freeradius -> in progress
 # TODO: change order of started containers: 1) adapter 2)backend containers not requiring the adapter 3) containers communicating via the adapter 4) update nginx.conf
 
-# env variables need for SSS
-$SSS_MYSQL_SCHEME = "sss";
-$SSS_MYSQL_USERNAME = "sss";
+#variables needed for SSS
+SSS_MYSQL_USERNAME="sss";
+SSS_MYSQL_SCHEME="sss";
+SSS_HOST=$(ifconfig  eth0 | awk '/inet addr/{print substr($2,6)}');
+SSS_PORT="8390";
+SSS_PORT_FOR_TOMCAT="8390";
+SSS_MYSQL_HOST=$(ifconfig  eth0 | awk '/inet addr/{print substr($2,6)}');
+SSS_MYSQL_PORT="3306";
+SSS_AUTH_TYPE="oidc";
+SSS_TETHYS_USER="SSSUser";
+SSS_TETHYS_PASSSWORD=""; #sss tethys password
+SSS_TETHYS_LAS_USER="sss";
+SSS_TETHYS_LAS_PASSWORD=""; #sss las password
+SSS_TETHYS_OIDC_CONF_URI="$LAYERS_API_URI/o/oauth2/.well-known/openid-configuration";
+SSS_TETHYS_OIDC_USER_END_POINT_URI="$LAYERS_API_URI/o/oauth2/userinfo";
 
-# create SSS database and user
-#echo "Creating SSS database and user..." &&
-#SSS_MYSQL_PASSWORD=`docker run --link mysql:mysql learninglayers/mysql-create -p$MYSQL_ROOT_PASSWORD --new-database $SSS_MYSQL_SCHEME --new-user $SSS_MYSQL_USERNAME | grep "mysql" | awk '{split($0,a," "); print a[3]}' | cut -c3-` &&
+#echo "Start SSS Tomcat server" &&
+#docker run -d -p 8080:8080 --name sss.tomcat learninglayers/tomcat &&
 #echo " -> done" &&
 #echo "" &&
 
-#echo "starting SSS container ..." &&
-#docker run \
-#-d \
-#-e "MYSQL_ROOT_USERNAME=root" \
-#-e "MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD" \
-#-e "SSS_HOST=host_with_out_protocol" \
-#-e "SSS_PORT=8390" \
-#-e "SSS_PORT_FOR_TOMCAT=8391" \
-#-e "SSS_MYSQL_HOST=host_with_out_protocol" \
-#-e "SSS_MYSQL_PORT=3333" \
+#echo "Create SSS database and user"
+#SSS_MYSQL_PASSWORD=`docker run --link mysql:mysql learninglayers/mysql-create -p$MYSQL_ROOT_PASSWORD --new-database $SSS_MYSQL_SCHEME --new-user $SSS_MYSQL_USERNAME | grep "mysql" | awk '{split($0,a," "); print a[3]}' | cut -c3-`
+#echo " -> done"
+#echo ""
+
+#echo "Start SSS" &&
+#docker run -d \
+#-e "SSS_HOST=$SSS_HOST" \
+#-e "SSS_PORT=$SSS_PORT" \
+#-e "SSS_PORT_FOR_TOMCAT=$SSS_PORT_FOR_TOMCAT" \
+#-e "SSS_MYSQL_HOST=$SSS_MYSQL_HOST" \
+#-e "SSS_MYSQL_PORT=$SSS_MYSQL_PORT" \
 #-e "SSS_MYSQL_USERNAME=$SSS_MYSQL_USERNAME" \
 #-e "SSS_MYSQL_PASSWORD=$SSS_MYSQL_PASSWORD" \
 #-e "SSS_MYSQL_SCHEME=$SSS_MYSQL_SCHEME" \
-#-e "SSS_AUTH_TYPE=oidc" \
-#-e "SSS_TETHYS_USER=sss_tethys_user" \
-#-e "SSS_TETHYS_PASSSWORD=sss_tethys_password" \
-#-e "SSS_TETHYS_LAS_USER=sss_las_user" \
-#-e "SSS_TETHYS_LAS_PASSWORD=sss_las_password" \
-#-e "SSS_TETHYS_OIDC_CONF_URI=https://api.learning-layers.eu/o/oauth2/.well-known/openid-configuration" \
-#-e "SSS_TETHYS_OIDC_USER_END_POINT_URI=https://api.learning-layers.eu/o/oauth2/userinfo" \
-#-p 8391:8390 \
-#--link mysql:mysql \
-#--volumes-from tomcat \
-#--name sss \
-#learninglayers/sss &&
-#echo "done --> starting SSS container ..."
+#-e "SSS_AUTH_TYPE=$SSS_AUTH_TYPE" \
+#-e "SSS_TETHYS_USER=$SSS_TETHYS_USER" \
+#-e "SSS_TETHYS_PASSSWORD=$SSS_TETHYS_PASSSWORD" \
+#-e "SSS_TETHYS_LAS_USER=$SSS_TETHYS_LAS_USER" \
+#-e "SSS_TETHYS_LAS_PASSWORD=$SSS_TETHYS_LAS_PASSWORD" \
+#-e "SSS_TETHYS_OIDC_CONF_URI=$SSS_TETHYS_OIDC_CONF_URI" \
+#-e "SSS_TETHYS_OIDC_USER_END_POINT_URI=$SSS_TETHYS_OIDC_USER_END_POINT_URI" \
+#-p $SSS_PORT_FOR_TOMCAT:$SSS_PORT --link mysql:mysql --volumes-from tomcat --volumes-from mysql-data --name sss learninglayers/sss &&
+#echo " -> done" &&
+#echo "" &&
 
 # register SSS REST API in OIDC
 #echo "Registering SSS REST API in OIDC..." &&

--- a/tomcat/Dockerfile
+++ b/tomcat/Dockerfile
@@ -43,6 +43,10 @@ ONBUILD RUN apt-get update -yq \
         && wget ${TARB_LOC} -O - | tar -zxv -C ${INSTALL_DIR}/ \
 	&& ln -s ${INSTALL_DIR}/apache-tomcat-${TOMCAT_MINOR_VER}/ ${TOMCAT_HOME}
 
+# Expose tomcat conf and webapps folder
+VOLUME ["/opt/tomcat/conf/","/opt/tomcat/webapps/"]
+
 # Expose Tomcat at port 8080 & start our initscripts		
+
 EXPOSE 8080
 CMD /bin/bash ${INIT_SH}


### PR DESCRIPTION
- mysql version increased
- exposed tomcat conf and webapps folder 
- adapted sss dockerfile
- integrated sss changes in start.sh with respect to mysql user creation and possible tomcat instantiation
- TODO:
  - layers sss image to be deployed in layers docker hub
  - layers java image to be deployed in layers docker hub: will switch for sss image to this then 
  - download sss image contents (currently sss v11.0.0) from jenkins instead of from git; wget http://layers.dbis.rwth-aachen.de/jenkins/job/SocialSemanticServer/lastSuccessfulBuild/artifact/*zip*/archive.zip did not work as .../artifact/xxx path is not available
